### PR TITLE
Remove PHP 5.x and PHP 7.0 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language:
   - php
 
 env:
-  - LARAVEL_VERSION=5.0.*
+  - LARAVEL_VERSION=5.2.*
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,38 +6,46 @@ env:
 
 matrix:
   include:
-    - php: 5.5
-      env: LARAVEL_VERSION=5.1.*
-    - php: 5.5
-      env: LARAVEL_VERSION=5.2.*
-    
-    - php: 5.6
-      env: LARAVEL_VERSION=5.2.*
-    - php: 5.6
-      env: LARAVEL_VERSION=5.3.*
-    - php: 5.6
-      env: LARAVEL_VERSION=5.4.*
-    
-    - php: 7.0
-      env: LARAVEL_VERSION=5.2.*
-    - php: 7.0
-      env: LARAVEL_VERSION=5.3.*
-    - php: 7.0
-      env: LARAVEL_VERSION=5.4.*
-    
     - php: 7.1
       env: LARAVEL_VERSION=5.2.*
     - php: 7.1
       env: LARAVEL_VERSION=5.3.*
     - php: 7.1
       env: LARAVEL_VERSION=5.4.*
-    
-    - php: hhvm
+    - php: 7.1
+      env: LARAVEL_VERSION=5.5.*
+
+    - php: 7.2
       env: LARAVEL_VERSION=5.2.*
-    - php: hhvm
+    - php: 7.2
       env: LARAVEL_VERSION=5.3.*
-    - php: hhvm
+    - php: 7.2
       env: LARAVEL_VERSION=5.4.*
+    - php: 7.2
+      env: LARAVEL_VERSION=5.5.*
+    - php: 7.2
+      env: LARAVEL_VERSION=5.6.*
+    - php: 7.2
+      env: LARAVEL_VERSION=5.7.*
+    - php: 7.2
+      env: LARAVEL_VERSION=5.8.*
+    - php: 7.2
+      env: LARAVEL_VERSION=6.*
+
+    - php: 7.3
+      env: LARAVEL_VERSION=5.2.*
+    - php: 7.3
+      env: LARAVEL_VERSION=5.3.*
+    - php: 7.3
+      env: LARAVEL_VERSION=5.4.*
+    - php: 7.3
+      env: LARAVEL_VERSION=5.5.*
+    - php: 7.3
+      env: LARAVEL_VERSION=5.6.*
+    - php: 7.3
+      env: LARAVEL_VERSION=5.7.*
+    - php: 7.3
+      env: LARAVEL_VERSION=5.8.*
 
 before_install:
   - travis_retry composer self-update

--- a/README.md
+++ b/README.md
@@ -10,8 +10,16 @@ Larinfo provide system information for Laravel 5.x application. It show IP addre
 
 To install using [Composer](https://getcomposer.org/), just run this command below.
 
+### For Laravel > 5.6
+
 ```bash
 composer require matriphe/larinfo
+```
+
+### For Laravel < 5.6
+
+```bash
+composer require matriphe/larinfo:1.0.2
 ```
 
 ### For Laravel 5.0, 5.1, 5.2, 5.3, and 5.4
@@ -28,7 +36,7 @@ Still on `config/app.php` file, add this line in `aliases` section.
 'Larinfo' => Matriphe\Larinfo\LarinfoFacade::class,
 ```
 
-### For Laravel 5.5
+### For Laravel > 5.5
 
 Nothing to do. It uses Laravel's package auto discovery.
 

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "sysinfo"
     ],
     "require": {
+        "php": "^7.1",
         "davidepastore/ipinfo": "^0.1.3",
         "laravel/framework": "^5.0",
         "linfo/linfo": "^3.0"

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,12 +16,12 @@ use Symfony\Component\HttpFoundation\Request;
 
 abstract class TestCase extends BaseTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Mockery::close();
 


### PR DESCRIPTION
Since PHP 5.x and 7.0 are not supported anymore, remove supports. Minimum Laravel version will be 5.2.