### PR TITLE
use an interface to bind in container

### DIFF
--- a/src/Larinfo.php
+++ b/src/Larinfo.php
@@ -8,7 +8,7 @@ use Linfo\Linfo;
 use PDO;
 use Symfony\Component\HttpFoundation\Request;
 
-class Larinfo
+class Larinfo implements LarinfoContract
 {
     /**
      * Define results

--- a/src/LarinfoContract.php
+++ b/src/LarinfoContract.php
@@ -1,0 +1,75 @@
+<?php 
+
+namespace Matriphe\Larinfo;
+
+interface LarinfoContract
+{
+    public function setDatabaseConfig($connection = []);
+
+    /**
+     * Set token for Ipinfo if exists.
+     *
+     * @access public
+     * @param string $token (default: null)
+     * @param bool   $debug (default: false)
+     */
+    public function setIpinfoConfig($token = null, $debug = false);
+
+    /**
+     * Get Host IP info.
+     *
+     * @access public
+     * @return arrah
+     */
+    public function getHostIpinfo();
+
+    /**
+     * Get Client IP info.
+     *
+     * @access public
+     * @return array
+     */
+    public function getClientIpinfo();
+
+    /**
+     * Get server software info.
+     *
+     * @access public
+     * @return array
+     */
+    public function getServerInfoSoftware();
+
+    /**
+     * Get server hardware info.
+     *
+     * @access public
+     * @return array
+     */
+    public function getServerInfoHardware();
+
+    /**
+     * Get server uptime.
+     *
+     * @access public
+     * @return array
+     */
+    public function getUptime();
+
+    /**
+     * Get server info.
+     *
+     * @access public
+     * @return array
+     */
+    public function getServerInfo();
+
+    public function getDatabaseInfo();
+
+    /**
+     * Get all info.
+     *
+     * @access public
+     * @return array
+     */
+    public function getInfo();
+}

--- a/src/LarinfoFacade.php
+++ b/src/LarinfoFacade.php
@@ -8,6 +8,6 @@ class LarinfoFacade extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return 'larinfo';
+        return LarinfoContract::class;
     }
 }

--- a/src/LarinfoServiceProvider.php
+++ b/src/LarinfoServiceProvider.php
@@ -24,7 +24,7 @@ class LarinfoServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('larinfo', function ($app) {
+        $this->app->singleton(LarinfoContract::class, function ($app) {
             $larinfo = new Larinfo(new Ipinfo(), new Request(), new Linfo(), new Manager());
 
             $token = config('services.ipinfo.token');


### PR DESCRIPTION
Hi,

Thanks for this package, very helpful, this is simply to use an interface to bind Larinfo in the container, so it can be used in constructors with dependency injection, without having to use the Facade :
```
public function __construct(LarinfoContract $larinfo)
{
    $this->larinfo = $larinfo;
}
```
I was previously using it like so :
```
public function __construct(Larinfo $larinfo)
{
    $this->larinfo = $larinfo;
}
```
and was running into problems since the logic defined in your provider wasn't called and the database connection wasn't set properly, which in my case was preventing some commands to work (migrate:status)