### PR TITLE
Support Laravel 9

### DIFF
--- a/.github/workflows/larinfo.yml
+++ b/.github/workflows/larinfo.yml
@@ -1,49 +1,15 @@
 name: Larinfo
 on: [push, pull_request]
 jobs:
-  ubuntu-laravel-5-6:
+  ubuntu-laravel-9:
     name: Laravel ${{ matrix.laravel-versions }} PHP ${{ matrix.php-versions }} ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
     strategy:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4']
-        laravel-versions: ['5.7.*', '5.8.*', '^6.20']
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup PHP with Composer
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-versions }}
-      - name: Check PHP Version and Modules
-        run: php -v && php -m
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v2
-        with:
-          path: vendor
-          key: ${{ runner.os }}-${{ matrix.operating-system }}-php-${{ matrix.php-versions }}-laravel-${{ matrix.laravel-versions }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.operating-system }}-php-${{ matrix.php-versions }}-laravel-${{ matrix.laravel-versions }}-
-      - name: Install Laravel
-        run: composer require "laravel/framework:${{ matrix.laravel-versions }}" --prefer-dist --no-progress
-      - name: Update Composer dependencies
-        run: composer update --prefer-dist --no-progress --no-suggest --optimize-autoloader
-      - name: Run Unit Tests
-        run: php vendor/bin/phpunit --group unit
-      - name: Run Ubuntu Tests
-        run: php vendor/bin/phpunit --group ubuntu
-  ubuntu-laravel-7-8:
-    name: Laravel ${{ matrix.laravel-versions }} PHP ${{ matrix.php-versions }} ${{ matrix.operating-system }}
-    runs-on: ${{ matrix.operating-system }}
-    strategy:
-      fail-fast: false
-      matrix:
-        operating-system: [ubuntu-latest]
-        php-versions: ['7.4', '8.0']
-        laravel-versions: ['^7.29', '^8.12']
+        php-versions: ['8.0']
+        laravel-versions: ['^9.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -71,7 +37,7 @@ jobs:
         run: vendor/bin/phpunit --group ubuntu
       - name: Run Larinfo Command
         run: php vendor/bin/testbench larinfo
-  macos-laravel-7-8:
+  macos-laravel-9:
     name: Laravel ${{ matrix.laravel-versions }} PHP ${{ matrix.php-versions }} ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
     strategy:
@@ -79,7 +45,7 @@ jobs:
       matrix:
         operating-system: [macos-10.15]
         php-versions: ['8.0']
-        laravel-versions: ['^7.29', '^8.12']
+        laravel-versions: ['^9.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -107,7 +73,7 @@ jobs:
         run: vendor/bin/phpunit --group macos
       - name: Run Larinfo Command
         run: php vendor/bin/testbench larinfo
-  windows-laravel-7-8:
+  windows-laravel-9:
     name: Laravel ${{ matrix.laravel-versions }} PHP ${{ matrix.php-versions }} ${{ matrix.operating-system }} without com_dotnet
     runs-on: ${{ matrix.operating-system }}
     strategy:
@@ -115,7 +81,7 @@ jobs:
       matrix:
         operating-system: [windows-2019]
         php-versions: ['8.0']
-        laravel-versions: ['^7.29', '^8.12']
+        laravel-versions: ['^9.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -144,7 +110,7 @@ jobs:
         run: vendor/bin/phpunit --group windows
       - name: Run Larinfo Command
         run: php vendor/bin/testbench larinfo
-  windows-with-com-dotnet-laravel-7-8:
+  windows-with-com-dotnet-laravel-9:
     name: Laravel ${{ matrix.laravel-versions }} PHP ${{ matrix.php-versions }} ${{ matrix.operating-system }} with com_dotnet
     runs-on: ${{ matrix.operating-system }}
     strategy:
@@ -152,7 +118,7 @@ jobs:
       matrix:
         operating-system: [windows-2019]
         php-versions: ['8.0']
-        laravel-versions: ['^7.29', '^8.12']
+        laravel-versions: ['^9.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ It wraps [Linfo](https://github.com/jrgp/linfo) to show IP address information o
 
 ## Requirements
 
-- **PHP version**: `^7.4` and `^8.0`.
-- **Laravel version**: `5.7.*`, `5.8.*`, `^6.0`, `^7.0`, and `^8.0`.
+- **PHP version**: `^8.0.2`.
+- **Laravel version**: `^9.0`.
 
 ### For Windows User
 
@@ -31,7 +31,8 @@ composer require matriphe/larinfo
 ```
 ### Older Version
 
-For older version, **[please check version 2.x](https://github.com/matriphe/larinfo/tree/2.2)** which supports Laravel `5.0`, `5.1`, `5.2`, `5.3`, `5.4`, `5.5`, and `5.6`.
+- Laravel `5.0`, `5.1`, `5.2`, `5.3`, `5.4`, `5.5`, and `5.6`, **[please use version 2.2](https://github.com/matriphe/larinfo/releases/tag/2.2)** by running `composer require matriphe/larinfo:2.2`.
+- Laravel `5.7.*`, `5.8.*`, `^6.0`, `^7.0`, and `^8.0`, **[please use version 3.0.0](https://github.com/matriphe/larinfo/releases/tag/3.0.0)** by running `composer require matriphe/larinfo:3.0.0`.
 
 ### Configuration
 

--- a/composer.json
+++ b/composer.json
@@ -10,16 +10,16 @@
         "sysinfo"
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0.2",
         "ext-pdo": "*",
         "davidepastore/ipinfo": "^0.6",
-        "laravel/framework": "5.7.*|5.8.*|^6.0|^7.0|^8.0",
+        "laravel/framework": "^9.0",
         "linfo/linfo": "^4.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^3.7|^4.0|^5.0|^6.0",
-        "phpunit/phpunit": "^7.0|^8.5|^9.5"
+        "orchestra/testbench": "^7.0",
+        "phpunit/phpunit": "^9.5"
     },
     "license": "GPL-3.0",
     "authors": [

--- a/src/Entities/HardwareInfo.php
+++ b/src/Entities/HardwareInfo.php
@@ -69,7 +69,7 @@ final class HardwareInfo extends LinfoEntity implements Arrayable
             $results[] = [
                 self::CPU_MODEL => $model,
                 self::CPU_VENDOR => $cpu['Vendor'] ?? null,
-                self::CPU_CLOCK_MHZ => $cpu['MHz'],
+                self::CPU_CLOCK_MHZ => $cpu['MHz'] ?? '',
                 self::CPU_USAGE_PERCENTAGE => $cpu['usage_percentage'] ?? null,
             ];
         }


### PR DESCRIPTION
This PR adds support for Laravel 9 and it drops support for older Laravel version (<= 8).

Output example for Apple M1 on Mac Mini

```
Larinfo
=======

+--------------------+---------------------------------+
| Application                                          |
+--------------------+---------------------------------+
| PHP version        | 8.0.18                          |
| Laravel version    | 9.9.0                           |
+--------------------+---------------------------------+
| Database                                             |
+--------------------+---------------------------------+
| Engine             | SQLite                          |
| Version            | 3.38.2                          |
+--------------------+---------------------------------+
| Operating System                                     |
+--------------------+---------------------------------+
| Type               | MacOS                           |
| Name               | MacOS 12.3.1                    |
| Architecture       | arm64                           |
| Kernel Version     | 21.4.0                          |
+--------------------+---------------------------------+
| Uptime                                               |
+--------------------+---------------------------------+
| Uptime             | 4 hours, 40 minutes, 39 seconds |
| First Boot         | 2022-04-24 16:54:14             |
+--------------------+---------------------------------+
| Server                                               |
+--------------------+---------------------------------+
| IP Address         | 84.130.239.3                    |
| Private IP Address |                                 |
| Hostname           | p5482ef03.dip0.t-ipconnect.de   |
| Provider           | AS3320 Deutsche Telekom AG      |
| City               | Berlin                          |
| Region             | Berlin                          |
| Country            | DE                              |
+--------------------+---------------------------------+
| Timezone                                             |
+--------------------+---------------------------------+
| Application        | UTC                             |
| Server Location    | Europe/Berlin                   |
+--------------------+---------------------------------+
| Hardware                                             |
+--------------------+---------------------------------+
| Model              | Mac mini                        |
| CPU count          | 8                               |
| CPU                | Apple M1                        |
+--------------------+---------------------------------+
| RAM                                                  |
+--------------------+---------------------------------+
| Total              | 16.0 GiB                        |
| Free               | 90.0 MiB                        |
+--------------------+---------------------------------+
| SWAP                                                 |
+--------------------+---------------------------------+
| Total              | 0.0 B                           |
| Free               | 0.0 B                           |
+--------------------+---------------------------------+
| Disk Space                                           |
+--------------------+---------------------------------+
| Total              | 2.2 TiB                         |
| Free               | 1.5 TiB                         |
+--------------------+---------------------------------+
```