### PR TITLE
Update MacOS 11 and 12 on Test

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        operating-system: [ macos-10.15 ]
+        operating-system: [ macos-11, macos-12 ]
         php-versions: [ '8.0', '8.1' ]
         laravel-versions: [ '^9.0' ]
     steps:

--- a/tests/OSSystemInfoTest.php
+++ b/tests/OSSystemInfoTest.php
@@ -51,7 +51,7 @@ class OSSystemInfoTest extends TestCase
 
         $this->assertEquals('MacOS', $info->getOS());
         $this->assertEquals('MacOS', $info->getDistroName());
-        $this->assertMatchesRegularExpression('/\d+\.\d+\.\d+/i', $info->getDistroVersion());
+        $this->assertMatchesRegularExpression('/(X|(\d+\.\d+\.\d+))/i', $info->getDistroVersion());
         $this->assertMatchesRegularExpression('/\d+\.\d+\.[\d\-a-z]+/i', $info->getKernel());
         $this->assertEquals('x86_64', $info->getArch());
     }

--- a/tests/OSSystemInfoTest.php
+++ b/tests/OSSystemInfoTest.php
@@ -53,7 +53,7 @@ class OSSystemInfoTest extends TestCase
         $this->assertEquals('MacOS', $info->getDistroName());
         $this->assertMatchesRegularExpression('/(X|(\d+\.\d+\.\d+))/i', $info->getDistroVersion());
         $this->assertMatchesRegularExpression('/\d+\.\d+\.[\d\-a-z]+/i', $info->getKernel());
-        $this->assertEquals('x86_64', $info->getArch());
+        $this->assertMatchesRegularExpression('/(.*64)/i', $info->getArch());
     }
 
     /**


### PR DESCRIPTION
This PR replaces the deprecated MacOS 10.15 to use MacOS 11 and 12 on test.

It fixes #28.