### PR TITLE
Replace `macos-12` with `macos-14` on GHA

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        operating-system: [ macos-12, macos-13 ]
+        operating-system: [ macos-13, macos-14 ]
         php-versions: [ '8.2', '8.3' ]
         laravel-versions: [ '11.*' ]
     steps:


### PR DESCRIPTION
Because `shivammathur/setup-php` doesn't support `macos-12` anymore.